### PR TITLE
Use pip install -r

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ there will be a `build/` dir which contains everything you need to run caffe,
 the Python bindings, etc.  The parent dir that contains `build/` will be your
 `CAFFE_ROOT` (we’ll need this later).
 * Running `make test && make runtest` should pass
-* After installing all the Python deps (doing `for req in $(cat requirements.txt); do pip install $req; done` in `python/`),
+* After installing all the Python deps (doing `pip install -r requirements.txt` in `python/`),
 running `make pycaffe && make pytest` should pass
 * You should also run `make distribute` in order to create a distributable version of caffe with all necessary headers, binaries, etc. in `distribute/`.
 


### PR DESCRIPTION
hello, there is a better way to install python deps from requirement files.
see: https://pip.pypa.io/en/stable/user_guide/#requirements-files

thanks for the great writeup!