### PR TITLE
Add docker quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,32 +199,20 @@ Pull the docker image from Docker Hub.
 docker pull kaixhin/digits
 ```
 
-Run the docker container.
+Run the docker container and get port number.
 
 ```bash
-docker run -dP kaixhin/digits
+docker port $(docker run -dP kaixhin/digits)
 ```
 
-Now that we have our container running we'll have to find the name of container and then find the port on which it's running on. 
-
-To find container name we'll run ```docker ps``` and find name of container which is running with kaixhin/digits image.
-In my case it's ```naughty_goldstine```.
-
-And to find out port number run ```docker port naughty_goldstine```.
-
-```bash
-docker ps
-docker port <container_name>
-```
-
-Open your web browser and type localhost followed by your port number http://localhost:1234
+Now that we have our container running you can open up your web browser and type localhost followed by your port number http://localhost:1234
 
 That's it. You got Caffe + DIGITS working.
 
 To get shell access
 
 ```bash
-docker exec -i -t naughty_goldstine /bin/bash
+docker exec -i -t name_of_container /bin/bash
 ```
 
 ##Training a Neural Network

--- a/README.md
+++ b/README.md
@@ -189,6 +189,38 @@ or modify the DIGITS startup script(s) to use the proper binary on your system.
 
 Once the server is started, you can do everything else via your web browser at http://localhost:5000, which is what I'll do below.
 
+###Docker Quick Start
+
+If you have docker installed then you can skip all the pain of installing Caffe + DIGITS and jump right in.
+
+Pull the docker image from Docker Hub.
+
+```bash
+docker pull kaixhin/digits
+```
+
+Run the docker container.
+
+```bash
+docker run -dP kaixhin/digits
+```
+
+Now that we have our container running we'll have to find the name of container and then find the port on which it's running on. 
+
+To find container name we'll run ```docker ps``` and find name of container which is running with kaixhin/digits image.
+In my case it's ```naughty_goldstine```.
+
+And to find out port number run ```docker port naughty_goldstine```.
+
+```bash
+docker ps
+docker port <container_name>
+```
+
+Open your web browser and type localhost followed by your port number http://localhost:1234
+
+That's it. You got Caffe + DIGITS working.
+
 ##Training a Neural Network
 
 Training a neural network involves a few steps:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ training and validating your network a lot easier.  We’ll be using
 [nVidia’s DIGITS](https://developer.nvidia.com/digits) tool below for just this purpose.
 
 Caffe can be a bit of work to get installed.  There are [installation instructions](http://caffe.berkeleyvision.org/installation.html)
-for various platforms, including some prebuilt Docker or AWS configurations.
+for various platforms, including some prebuilt Docker or AWS configurations.  
 
 **NOTE:** when making my walkthrough, I used the following non-released version of Caffe from their Github repo:
 https://github.com/BVLC/caffe/commit/5a201dd960840c319cefd9fa9e2a40d2c76ddd73
@@ -191,28 +191,22 @@ Once the server is started, you can do everything else via your web browser at h
 
 ###Docker Quick Start
 
-If you have docker installed then you can skip all the pain of installing Caffe + DIGITS and jump right in.
+If you have Docker installed (it's really simple) then you can skip all the pain of installing Caffe + DIGITS and jump right in.
 
-Pull the docker image from Docker Hub.
+Pull & run the Docker container. Make sure port 8080 isn't allocated by another program. If so, change it to any other port you want.  
 
 ```bash
-docker pull kaixhin/digits
+docker run --name="digits" -d -p 8080:5000 kaixhin/digits
 ```
 
-Run the docker container and get port number.
+Now that we have our container running you can open up your web browser and open http://localhost:8080.
+
+That's it. You got Caffe and DIGITS working.
+
+If you need shell access:
 
 ```bash
-docker port $(docker run -dP kaixhin/digits)
-```
-
-Now that we have our container running you can open up your web browser and type localhost followed by your port number http://localhost:1234
-
-That's it. You got Caffe + DIGITS working.
-
-To get shell access
-
-```bash
-docker exec -i -t $(docker ps -q  --filter=ancestor=kaixhin/digits) /bin/bash
+docker exec -it digits /bin/bash
 ```
 
 ##Training a Neural Network

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ If you have Docker installed (it's really simple) then you can skip all the pain
 Pull & run the Docker container. Make sure port 8080 isn't allocated by another program. If so, change it to any other port you want.  
 
 ```bash
-docker run --name="digits" -d -p 8080:5000 kaixhin/digits
+docker run --name="digits" -d -p 8080:5000 -v /path/to/this/repository:/data/repo /kaixhin/digits
 ```
 
-Now that we have our container running you can open up your web browser and open http://localhost:8080.
+Now that we have our container running you can open up your web browser and open http://localhost:8080. Everything in the repository is now in the container directory `/data/repo`.
 
 That's it. You got Caffe and DIGITS working.
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ That's it. You got Caffe + DIGITS working.
 To get shell access
 
 ```bash
-docker exec -i -t name_of_container /bin/bash
+docker exec -i -t $(docker ps -q  --filter=ancestor=kaixhin/digits) /bin/bash
 ```
 
 ##Training a Neural Network

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ Open your web browser and type localhost followed by your port number http://loc
 
 That's it. You got Caffe + DIGITS working.
 
+To get shell access
+
+```bash
+docker exec -i -t naughty_goldstine /bin/bash
+```
+
 ##Training a Neural Network
 
 Training a neural network involves a few steps:


### PR DESCRIPTION
It's a pain to get Caffe + DIGITS working and takes a lot of time to get started. That's why I have added this so that who has docker installed can get started easily.

I wasn't sure about the location where to put this so I have added to the bottom of installation. 
Feel free to change it.

Thanks,
Swar